### PR TITLE
Fix gh-pages deploy silently dropping the pack ZIPs

### DIFF
--- a/.github/workflows/deploy-claude-preview.yml
+++ b/.github/workflows/deploy-claude-preview.yml
@@ -31,3 +31,7 @@ jobs:
           publish_dir: .
           destination_dir: preview-working
           keep_files: true
+          # See the same line in deploy-main-production.yml: without this,
+          # .gitignore rides along onto the gh-pages checkout and its pack/
+          # exclusion silently drops the built ZIPs from the publish commit.
+          exclude_assets: .github,.gitignore

--- a/.github/workflows/deploy-main-production.yml
+++ b/.github/workflows/deploy-main-production.yml
@@ -32,3 +32,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .
           keep_files: true
+          # keep_files copies the whole working tree - including .gitignore -
+          # onto the gh-pages checkout before this action's own `git add --all`
+          # runs there. Left in place, .gitignore's pack/ exclusion (meant only
+          # to keep the CI-built pack out of the *source* branch) silently kept
+          # it out of every gh-pages publish commit too: the build step logged
+          # success and the ZIPs existed on disk, but "git commit" never staged
+          # them, so the site kept 404ing on pack/*.zip after every deploy.
+          exclude_assets: .github,.gitignore


### PR DESCRIPTION
## Summary

- `peaceiris/actions-gh-pages` copies the whole working tree - `.gitignore` included - onto its `gh-pages` clone before running its own `git add --all` there (`keep_files: true`).
- The repo-root `.gitignore` excludes `AkaiMPCChordProgressionGenerator/pack/`, which is correct for keeping the CI-built pack out of `main`'s history (D7 in `docs/mpc-export-specification.md`). Riding along onto the `gh-pages` clone, that same rule excluded the pack from the *publish* commit too.
- `build-pack.mjs` ran and logged success on both deploys since the pack shipped (839 `.progression` files, 10065 MIDI files), the ZIPs existed on disk and got copied over - but were never staged, so `pack/*.zip` 404'd despite a green workflow run. Confirmed directly: the publish commit for the latest deploy touched exactly 8 files, and `AkaiMPCChordProgressionGenerator/pack/` is absent from the `gh-pages` branch entirely.
- Both workflows that publish to `gh-pages` (`deploy-main-production.yml`, `deploy-claude-preview.yml`) now pass `exclude_assets: .github,.gitignore`, stripping `.gitignore` itself from what gets copied onto the `gh-pages` checkout, alongside the existing `.github` exclusion.

## Test plan

- [x] Validated both workflow files as YAML
- [x] Verified the comma-separated `exclude_assets` format against `peaceiris/actions-gh-pages`'s own source (`excludeAssets.split(',')` in `src/git-utils.ts`)
- [ ] After merge, confirm the next push to `main` (this merge itself will trigger it) redeploys with `pack/AkaiMPC-Chord-Progressions.zip` and `pack/AkaiMPC-Chord-MIDI.zip` actually reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF)_