### PR TITLE
Fold the bulk-export button into the hint sentence as an inline link

### DIFF
--- a/AkaiMPCChordProgressionGenerator/index.html
+++ b/AkaiMPCChordProgressionGenerator/index.html
@@ -170,11 +170,13 @@
 
         <div id="progressionsContainer" class="progressions hidden"></div>
 
-        <div class="bulk-export" id="bulkExport">
-            <p class="bulk-export-hint" data-i18n="buttons.bulkCatalogHint">Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go - every progression this generator can make, pre-built:</p>
-            <a class="secondary-link" id="bulkExportProgressions" data-context="mpc" href="pack/AkaiMPC-Chord-Progressions.zip" download data-i18n="buttons.bulkCatalogProgressions">Download the whole catalogue as .progression files (key of C - Pad Perform transposes on import)</a>
-            <a class="secondary-link hidden" id="bulkExportMidi" data-context="midi" href="pack/AkaiMPC-Chord-MIDI.zip" download data-i18n="buttons.bulkCatalogMidi">Download the whole catalogue as MIDI files (all twelve keys)</a>
-        </div>
+        <p class="bulk-export-hint" id="bulkExport">
+            <span data-i18n="buttons.bulkCatalogHint">Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go -</span>
+            <a id="bulkExportProgressions" data-context="mpc" href="pack/AkaiMPC-Chord-Progressions.zip" download data-i18n="buttons.bulkCatalogDownloadLink">download every progression this generator can make, pre-built</a>
+            <a class="hidden" id="bulkExportMidi" data-context="midi" href="pack/AkaiMPC-Chord-MIDI.zip" download data-i18n="buttons.bulkCatalogDownloadLink">download every progression this generator can make, pre-built</a>
+            <span data-context="mpc" data-i18n="buttons.bulkCatalogProgressionsDetail">(key of C - Pad Perform transposes on import).</span>
+            <span class="hidden" data-context="midi" data-i18n="buttons.bulkCatalogMidiDetail">(all twelve keys).</span>
+        </p>
 
         <footer>
             <p>

--- a/AkaiMPCChordProgressionGenerator/locales/de.json
+++ b/AkaiMPCChordProgressionGenerator/locales/de.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Alle MIDI-Dateien herunterladen",
     "printAll": "Alle Progressionen drucken",
     "download": "Herunterladen",
-    "bulkCatalogHint": "Progressionen auf Abruf sind nicht so dein Ding? Lieber durch Hunderte Dateien wühlen? Bitte sehr - jede Progression, die dieser Generator erzeugen kann, fertig gebaut:",
-    "bulkCatalogProgressions": "Den gesamten Katalog als .progression-Dateien herunterladen (Tonart C - Pad Perform transponiert beim Import)",
-    "bulkCatalogMidi": "Den gesamten Katalog als MIDI-Dateien herunterladen (alle zwölf Tonarten)"
+    "bulkCatalogHint": "Progressionen auf Abruf sind nicht so dein Ding? Lieber durch Hunderte Dateien wühlen? Bitte sehr -",
+    "bulkCatalogDownloadLink": "lade jede Progression herunter, die dieser Generator erzeugen kann, fertig gebaut",
+    "bulkCatalogProgressionsDetail": "(Tonart C - Pad Perform transponiert beim Import).",
+    "bulkCatalogMidiDetail": "(alle zwölf Tonarten)."
   },
   "tabs": {
     "mpc": "MPC-Pads",

--- a/AkaiMPCChordProgressionGenerator/locales/en.json
+++ b/AkaiMPCChordProgressionGenerator/locales/en.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Download all MIDI files",
     "printAll": "Print all progressions",
     "download": "Download",
-    "bulkCatalogHint": "Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go - every progression this generator can make, pre-built:",
-    "bulkCatalogProgressions": "Download the whole catalogue as .progression files (key of C - Pad Perform transposes on import)",
-    "bulkCatalogMidi": "Download the whole catalogue as MIDI files (all twelve keys)"
+    "bulkCatalogHint": "Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go -",
+    "bulkCatalogDownloadLink": "download every progression this generator can make, pre-built",
+    "bulkCatalogProgressionsDetail": "(key of C - Pad Perform transposes on import).",
+    "bulkCatalogMidiDetail": "(all twelve keys)."
   },
   "tabs": {
     "mpc": "MPC Pads",

--- a/AkaiMPCChordProgressionGenerator/locales/es.json
+++ b/AkaiMPCChordProgressionGenerator/locales/es.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Descargar todos los archivos MIDI",
     "printAll": "Imprimir todas las progresiones",
     "download": "Descargar",
-    "bulkCatalogHint": "¿Las progresiones personalizadas al vuelo no son lo tuyo? ¿Prefieres bucear entre cientos de archivos? Aquí las tienes - todas las progresiones que este generador puede crear, ya preparadas:",
-    "bulkCatalogProgressions": "Descargar todo el catálogo como archivos .progression (tonalidad de Do - Pad Perform transpone al importar)",
-    "bulkCatalogMidi": "Descargar todo el catálogo como archivos MIDI (las doce tonalidades)"
+    "bulkCatalogHint": "¿Las progresiones personalizadas al vuelo no son lo tuyo? ¿Prefieres bucear entre cientos de archivos? Aquí las tienes -",
+    "bulkCatalogDownloadLink": "descarga todas las progresiones que este generador puede crear, ya preparadas",
+    "bulkCatalogProgressionsDetail": "(tonalidad de Do - Pad Perform transpone al importar).",
+    "bulkCatalogMidiDetail": "(las doce tonalidades)."
   },
   "tabs": {
     "mpc": "Pads MPC",

--- a/AkaiMPCChordProgressionGenerator/locales/fr.json
+++ b/AkaiMPCChordProgressionGenerator/locales/fr.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Télécharger tous les fichiers MIDI",
     "printAll": "Imprimer toutes les progressions",
     "download": "Télécharger",
-    "bulkCatalogHint": "Les progressions personnalisées à la demande, ce n'est pas votre tasse de thé ? Vous préférez patauger dans des centaines de fichiers ? Voilà - toutes les progressions que ce générateur peut produire, prêtes à l'emploi :",
-    "bulkCatalogProgressions": "Télécharger tout le catalogue en fichiers .progression (tonalité de Do - Pad Perform transpose à l'import)",
-    "bulkCatalogMidi": "Télécharger tout le catalogue en fichiers MIDI (les douze tonalités)"
+    "bulkCatalogHint": "Les progressions personnalisées à la demande, ce n'est pas votre tasse de thé ? Vous préférez patauger dans des centaines de fichiers ? Voilà -",
+    "bulkCatalogDownloadLink": "téléchargez toutes les progressions que ce générateur peut produire, prêtes à l'emploi",
+    "bulkCatalogProgressionsDetail": "(tonalité de Do - Pad Perform transpose à l'import).",
+    "bulkCatalogMidiDetail": "(les douze tonalités)."
   },
   "tabs": {
     "mpc": "Pads MPC",

--- a/AkaiMPCChordProgressionGenerator/locales/it.json
+++ b/AkaiMPCChordProgressionGenerator/locales/it.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Scarica tutti i file MIDI",
     "printAll": "Stampa tutte le progressioni",
     "download": "Scarica",
-    "bulkCatalogHint": "Le progressioni personalizzate su richiesta non fanno per te? Preferisci districarti tra centinaia di file? Ecco qui - ogni progressione che questo generatore può creare, già pronta:",
-    "bulkCatalogProgressions": "Scarica l'intero catalogo come file .progression (tonalità di Do - Pad Perform trasporta all'importazione)",
-    "bulkCatalogMidi": "Scarica l'intero catalogo come file MIDI (tutte le dodici tonalità)"
+    "bulkCatalogHint": "Le progressioni personalizzate su richiesta non fanno per te? Preferisci districarti tra centinaia di file? Ecco qui -",
+    "bulkCatalogDownloadLink": "scarica ogni progressione che questo generatore può creare, già pronta",
+    "bulkCatalogProgressionsDetail": "(tonalità di Do - Pad Perform trasporta all'importazione).",
+    "bulkCatalogMidiDetail": "(tutte le dodici tonalità)."
   },
   "tabs": {
     "mpc": "Pad MPC",

--- a/AkaiMPCChordProgressionGenerator/locales/pt.json
+++ b/AkaiMPCChordProgressionGenerator/locales/pt.json
@@ -55,9 +55,10 @@
     "downloadAllMidi": "Baixar todos os arquivos MIDI",
     "printAll": "Imprimir todas as progressões",
     "download": "Baixar",
-    "bulkCatalogHint": "Progressões personalizadas sob demanda não é bem sua praia? Prefere vasculhar centenas de arquivos? Aí está - toda progressão que este gerador pode criar, pronta:",
-    "bulkCatalogProgressions": "Baixar todo o catálogo como arquivos .progression (tom de Dó - o Pad Perform transpõe na importação)",
-    "bulkCatalogMidi": "Baixar todo o catálogo como arquivos MIDI (as doze tonalidades)"
+    "bulkCatalogHint": "Progressões personalizadas sob demanda não é bem sua praia? Prefere vasculhar centenas de arquivos? Aí está -",
+    "bulkCatalogDownloadLink": "baixe toda progressão que este gerador pode criar, pronta",
+    "bulkCatalogProgressionsDetail": "(tom de Dó - o Pad Perform transpõe na importação).",
+    "bulkCatalogMidiDetail": "(as doze tonalidades)."
   },
   "tabs": {
     "mpc": "Pads MPC",

--- a/AkaiMPCChordProgressionGenerator/styles.css
+++ b/AkaiMPCChordProgressionGenerator/styles.css
@@ -1268,44 +1268,25 @@ body[data-context="staff"] .chord-staff {
     display: none;
 }
 
-/* Bulk catalogue export links - not the happy path, just an affordance for
-   users who want to manage hundreds of files by hand, so they sit quietly
+/* Bulk catalogue export hint - not the happy path, just an affordance for
+   users who want to manage hundreds of files by hand, so it sits quietly
    below the generated cards rather than competing with Generate/Download. */
-.bulk-export {
-    margin-top: 24px;
+.bulk-export-hint {
+    margin: 24px 0 0;
     padding-top: 16px;
     border-top: 1px solid var(--border);
-}
-
-.bulk-export-hint {
-    margin: 0 0 8px;
     font-size: 13px;
     color: var(--muted);
 }
 
-.secondary-link {
-    display: inline-block;
-    padding: 8px 12px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    background: var(--pad-bg);
-    color: var(--muted);
-    font-size: 13px;
-    font-weight: 500;
+.bulk-export-hint a {
+    color: var(--accent);
     text-decoration: none;
-    transition: all 0.2s ease;
+    font-weight: 500;
 }
 
-.secondary-link:hover {
-    background: var(--pad-hover);
-    color: var(--fg);
-}
-
-/* .hidden and .secondary-link both set `display` at equal specificity, so
-   whichever rule comes later in the file would otherwise win regardless of
-   which one the markup actually needs - pin it explicitly instead. */
-.secondary-link.hidden {
-    display: none;
+.bulk-export-hint a:hover {
+    text-decoration: underline;
 }
 
 footer {


### PR DESCRIPTION
## Summary

- Collapses the separate "download" button below the bulk-export hint paragraph into the hint itself: the call to action is now an inline hyperlink, matching the sentence's tone instead of sitting apart as its own block-level button.
- The format-specific detail ("key of C - Pad Perform transposes on import" / "all twelve keys") stays as plain text trailing the link rather than folded into the clickable phrase, so screen readers and copy-pasted link text don't carry it.
- The old markup relied on each `<a>` holding its own complete label. `updatePageTranslations()` only handles elements with either zero children (sets `textContent`) or multiple text-node children all sharing one translation - the latter is broken for "lead-in text + link + trailing detail" around a shared inline element, since every text node would get overwritten with the same string. The sentence is now built from independently-translated leaf elements (lead-in `<span>`, `<a>`, detail `<span>`) instead.
- Context switching (MPC Pads → `.progression` pack / MIDI → MIDI pack / other tabs → hidden) reuses the existing `data-context` + `switchContext()` mechanism unchanged, just now targeting inline elements instead of block-level buttons.

fr/es/de/it/pt translations are drafts, not native-reviewed.

## Test plan

- [x] Verified via a live browser (Playwright) that: the MPC link is visible by default with the correct href, clicking the MIDI tab swaps visibility and detail text correctly, clicking Guitar hides the whole hint, and switching the UI language to French re-translates all three fragments (lead-in, link, detail) correctly - confirming the leaf-element translation approach actually works, not just in theory
- [x] Screenshotted the rendered sentence to confirm the link reads naturally inline with correct accent-color styling
- [x] Validated all six locale JSON files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF)_