### PR TITLE
Non-breaking spaces in the bulk-export hint, drop its horizontal rule

### DIFF
--- a/AkaiMPCChordProgressionGenerator/index.html
+++ b/AkaiMPCChordProgressionGenerator/index.html
@@ -171,10 +171,9 @@
         <div id="progressionsContainer" class="progressions hidden"></div>
 
         <p class="bulk-export-hint" id="bulkExport">
-            <span data-i18n="buttons.bulkCatalogHint">Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go -</span>
-            <a id="bulkExportProgressions" data-context="mpc" href="pack/AkaiMPC-Chord-Progressions.zip" download data-i18n="buttons.bulkCatalogDownloadLink">download every progression this generator can make, pre-built</a>
+            <span data-i18n="buttons.bulkCatalogHint">Custom progressions on-demand isn't your cup of tea&nbsp;? Prefer to wade through hundreds of files&nbsp;? There you go&nbsp;-</span>&nbsp;<a id="bulkExportProgressions" data-context="mpc" href="pack/AkaiMPC-Chord-Progressions.zip" download data-i18n="buttons.bulkCatalogDownloadLink">download every progression this generator can make, pre-built</a>
             <a class="hidden" id="bulkExportMidi" data-context="midi" href="pack/AkaiMPC-Chord-MIDI.zip" download data-i18n="buttons.bulkCatalogDownloadLink">download every progression this generator can make, pre-built</a>
-            <span data-context="mpc" data-i18n="buttons.bulkCatalogProgressionsDetail">(key of C - Pad Perform transposes on import).</span>
+            <span data-context="mpc" data-i18n="buttons.bulkCatalogProgressionsDetail">(key of C&nbsp;-&nbsp;Pad Perform transposes on import).</span>
             <span class="hidden" data-context="midi" data-i18n="buttons.bulkCatalogMidiDetail">(all twelve keys).</span>
         </p>
 

--- a/AkaiMPCChordProgressionGenerator/locales/en.json
+++ b/AkaiMPCChordProgressionGenerator/locales/en.json
@@ -55,9 +55,9 @@
     "downloadAllMidi": "Download all MIDI files",
     "printAll": "Print all progressions",
     "download": "Download",
-    "bulkCatalogHint": "Custom progressions on-demand isn't your cup of tea? Prefer to wade through hundreds of files? There you go -",
+    "bulkCatalogHint": "Custom progressions on-demand isn't your cup of tea ? Prefer to wade through hundreds of files ? There you go -",
     "bulkCatalogDownloadLink": "download every progression this generator can make, pre-built",
-    "bulkCatalogProgressionsDetail": "(key of C - Pad Perform transposes on import).",
+    "bulkCatalogProgressionsDetail": "(key of C - Pad Perform transposes on import).",
     "bulkCatalogMidiDetail": "(all twelve keys)."
   },
   "tabs": {

--- a/AkaiMPCChordProgressionGenerator/styles.css
+++ b/AkaiMPCChordProgressionGenerator/styles.css
@@ -1274,7 +1274,6 @@ body[data-context="staff"] .chord-staff {
 .bulk-export-hint {
     margin: 24px 0 0;
     padding-top: 16px;
-    border-top: 1px solid var(--border);
     font-size: 13px;
     color: var(--muted);
 }


### PR DESCRIPTION
## Summary

- The English bulk-export hint now uses U+00A0 (non-breaking space) surrounding both standalone " - " separators and preceding both "?" marks, so the line can no longer wrap right after either. Word-internal hyphens (`on-demand`, `pre-built`) are untouched.
- The lead-in `<span>` and the download `<a>` are two separate DOM elements (needed so the translation engine can update each independently - see PR #95), so the non-breaking space between "go" and "download" is an explicit `&nbsp;` in the markup itself rather than baked into either translatable string.
- Removed the horizontal rule (`border-top`) that previously sat above the paragraph; the existing top margin/padding is unchanged, so the paragraph keeps the same vertical spacing from the generated cards above it, just without the line.
- Scope: only the English strings in `index.html` and `locales/en.json`. The other five locales' dash/question-mark spacing is untouched - French already uses non-breaking spaces before `?`/`:` per its own typographic convention (unrelated to this change), and Spanish/German/Italian/Portuguese have no such convention to begin with.

## Test plan

- [x] Verified in a live browser that each of the four marks (both "?" and both standalone "-") sits next to U+00A0, not a plain space, by inspecting character codes directly rather than just eyeballing the render
- [x] Confirmed computed `border-top` on the hint is `none`
- [x] Screenshotted the rendered sentence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwQCigYZxdGBW3kPWnMMgF)_